### PR TITLE
use native promise if possible

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,15 @@ Exeq.prototype.run = function(resolve, reject) {
 };
 
 module.exports = function() {
-  return new Exeq(Array.prototype.slice.call(arguments));
+  var cmds = [], args = Array.prototype.slice.call(arguments);
+  args.forEach(function(arg) {
+    if (Array.isArray(arg)) {
+      cmds = cmds.concat(arg);
+    } else {
+      cmds.push(arg);
+    }
+  });
+  return new Exeq(cmds);
 };
 
 function parseCommand(cmd) {

--- a/package.json
+++ b/package.json
@@ -23,9 +23,10 @@
   },
   "license": "MIT",
   "dependencies": {
-    "q": "^1.1.2"
+    "native-or-bluebird": "~1.1.2"
   },
   "devDependencies": {
+    "bluebird": "^2.6.4",
     "is-promise": "~1.0.1",
     "tap": "*"
   },

--- a/tests/command-name.js
+++ b/tests/command-name.js
@@ -3,8 +3,10 @@ var exeq = require('..');
 
 test('command name', function(t) {
   exeq(
-    'ls -l',
-    'cd ..',
+    [
+      'ls -l',
+      'cd ..'
+    ],
     'ps'
   ).then(function(results) {
     t.equal(results[0].cmd, 'ls -l');


### PR DESCRIPTION
替换掉 q，Promise 接口和标准保持一致，如果使用的 node 版本不支持则使用方自己安装 bluebird。